### PR TITLE
Fix color contrast on some terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ Alternatives such as Uni-Curses seem unreliable, but I'd be willing to try a sim
 
 - [X] Expose more options as command line arguments
 
-- [ ] Fix terrible colour contrast on some terminals
+- [X] Fix terrible colour contrast on some terminals
 
 - [ ] Hard mode

--- a/curdle.py
+++ b/curdle.py
@@ -54,7 +54,14 @@ if __name__ == '__main__':
         help="use smaller wordlist for allowed guesses")
     # hidden options
     parser.add_argument( "--noborder",
+        default=False,
         dest="no_border",
+        action="store_true",
+        help=argparse.SUPPRESS)
+    # recommended with Konsole
+    parser.add_argument( "--simplecolor",
+        default=False,
+        dest="simplecolor",
         action="store_true",
         help=argparse.SUPPRESS)
     parser.add_argument( "--layout",
@@ -81,6 +88,8 @@ if __name__ == '__main__':
         config.maxguesses = args.tries
     if args.no_border:
         config.drawborder = False
+    if args.simplecolor:
+        config.simplecolor = True
     if args.layout:
         config.setlayout(args.layout)
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -45,7 +45,6 @@ class Config():
     wordlen = len(solution)
     showsolution = True
     drawborder = True
-    invertcolors = False
     maxspacing = 3
     maxguesses = 6
     kblayout = _LAYOUTS['qwerty']

--- a/modules/config.py
+++ b/modules/config.py
@@ -45,6 +45,7 @@ class Config():
     wordlen = len(solution)
     showsolution = True
     drawborder = True
+    simplecolor = False
     maxspacing = 3
     maxguesses = 6
     kblayout = _LAYOUTS['qwerty']

--- a/modules/game.py
+++ b/modules/game.py
@@ -219,7 +219,7 @@ class Game():
 
     def _create_wins(self, stdscr):
         # a whole nightmare in the palm of your hand!
-        Game._set_colors()
+        self._set_colors()
         max_y = curses.LINES - 1
         max_x = curses.COLS - 1
         mid_x = round(max_x / 2)
@@ -263,10 +263,12 @@ class Game():
         return win_wrds, win_msg, win_kb
 
 
-    @classmethod
-    def _set_colors(cls):
+    def _set_colors(self):
+        # note, some terminals, such as Konsole, straight up lie about being
+        # able to change colors, i'm not entirely sure why. you may want to
+        # force simplecolor in that case (or switch to a better terminal)
         curses.use_default_colors() # maps '-1' to background
-        if curses.can_change_color():
+        if curses.can_change_color() and not self.CONST.simplecolor:
             curses.init_color(1, 11, 913, 556) # green
             curses.init_pair(Status.MATCH, 1, -1)
             curses.init_color(2, 984, 729, 337) # yellow

--- a/modules/game.py
+++ b/modules/game.py
@@ -219,7 +219,7 @@ class Game():
 
     def _create_wins(self, stdscr):
         # a whole nightmare in the palm of your hand!
-        Game._set_colors(self.CONST.invertcolors)
+        Game._set_colors()
         max_y = curses.LINES - 1
         max_x = curses.COLS - 1
         mid_x = round(max_x / 2)
@@ -264,25 +264,17 @@ class Game():
 
 
     @classmethod
-    def _set_colors(cls, inverted=False):
+    def _set_colors(cls):
         # this might be important on some terminals, not on kitty or konsole
         curses.use_default_colors()
-        if not inverted:
-            # pair 0 is a constant and always points to the default fg/bg colors
-            # related: on most systems I tested COLOR_BACK is actually grey
-            curses.init_pair(Status.MATCH,
-                             curses.COLOR_GREEN, curses.COLOR_BLACK)
-            curses.init_pair(Status.MISPLACE,
-                             curses.COLOR_YELLOW, curses.COLOR_BLACK)
-            curses.init_pair(Status.MISMATCH,
-                             curses.COLOR_WHITE, curses.COLOR_BLACK)
-        else:
-            curses.init_pair(Status.MATCH,
-                             curses.COLOR_BLACK, curses.COLOR_GREEN)
-            curses.init_pair(Status.MISPLACE,
-                             curses.COLOR_BLACK, curses.COLOR_YELLOW)
-            curses.init_pair(Status.MISMATCH,
-                             curses.COLOR_BLACK, curses.COLOR_WHITE)
+        # pair 0 is a constant and always points to the default fg/bg colors
+        # related: on most systems I tested COLOR_BACK is actually grey
+        curses.init_pair(Status.MATCH,
+                         curses.COLOR_GREEN, curses.COLOR_BLACK)
+        curses.init_pair(Status.MISPLACE,
+                         curses.COLOR_YELLOW, curses.COLOR_BLACK)
+        curses.init_pair(Status.MISMATCH,
+                         curses.COLOR_WHITE, curses.COLOR_BLACK)
 
 
     @classmethod

--- a/modules/game.py
+++ b/modules/game.py
@@ -265,16 +265,18 @@ class Game():
 
     @classmethod
     def _set_colors(cls):
-        # this might be important on some terminals, not on kitty or konsole
-        curses.use_default_colors()
-        # pair 0 is a constant and always points to the default fg/bg colors
-        # related: on most systems I tested COLOR_BACK is actually grey
-        curses.init_pair(Status.MATCH,
-                         curses.COLOR_GREEN, curses.COLOR_BLACK)
-        curses.init_pair(Status.MISPLACE,
-                         curses.COLOR_YELLOW, curses.COLOR_BLACK)
-        curses.init_pair(Status.MISMATCH,
-                         curses.COLOR_WHITE, curses.COLOR_BLACK)
+        curses.use_default_colors() # maps '-1' to background
+        if curses.can_change_color():
+            curses.init_color(1, 11, 913, 556) # green
+            curses.init_pair(Status.MATCH, 1, -1)
+            curses.init_color(2, 984, 729, 337) # yellow
+            curses.init_pair(Status.MISPLACE, 2, -1)
+            curses.init_color(3, 615, 600, 811) # gray-ish
+            curses.init_pair(Status.MISMATCH, 3, -1)
+        else:
+            curses.init_pair(Status.MATCH, curses.COLOR_GREEN, -1)
+            curses.init_pair(Status.MISPLACE, curses.COLOR_YELLOW, -1)
+            curses.init_pair(Status.MISMATCH, curses.COLOR_MAGENTA, -1)
 
 
     @classmethod


### PR DESCRIPTION
Tested on alacritty, xterm, urxvt, kitty, and gnome-console. Konsole (KDE) inexplicably cannot change colors and should use --simplecolors as a fallback instead.